### PR TITLE
Additional dags corresponding to some maintenance scripts

### DIFF
--- a/dags/restic_backup__force.py
+++ b/dags/restic_backup__force.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+
+from builtins import range
+from datetime import datetime, timedelta
+
+import airflow
+from airflow.models import DAG
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.dummy_operator import DummyOperator
+
+def msys2_bash_invocation(command, msys2_bash='/c/scoop/apps/msys2/current/usr/bin/bash.exe'):
+    return '{0} -l -c "{1}"'.format(msys2_bash, command)
+
+args = {
+    'owner': 'restic',
+    'depends_on_past': False,
+    # 'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': datetime(2020, 7, 11),
+    'retries': 2,
+    'retry_delay': timedelta(minutes=15),
+}
+
+dag = DAG(
+    dag_id='restic_backup__force',
+    dagrun_timeout=timedelta(minutes=90),
+    schedule_interval=None,
+    catchup=False,
+    default_args=args,
+)
+
+run_this_last = DummyOperator(
+    task_id='run_END',
+    dag=dag,
+)
+
+run_restic_backup = BashOperator(
+    task_id='run_restic_backup',
+    bash_command=msys2_bash_invocation("restic-run-backup--force"),
+    dag=dag,
+)
+
+run_restic_check = BashOperator(
+    task_id='run_restic_check',
+    bash_command=msys2_bash_invocation("restic-do-check"),
+    dag=dag,
+)
+
+#run_restic_forget = BashOperator(
+#    task_id='run_restic_forget',
+#    bash_command=msys2_bash_invocation("restic-forget-according-to-my-policy"),
+#    dag=dag,
+#)
+
+#run_restic_backup >> run_restic_check >> run_restic_forget >> run_this_last
+run_restic_backup >> run_restic_check >> run_this_last
+
+if __name__ == "__main__":
+    dag.cli()

--- a/dags/restic_check__read_data.py
+++ b/dags/restic_check__read_data.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+
+from builtins import range
+from datetime import datetime, timedelta
+
+import airflow
+from airflow.models import DAG
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.dummy_operator import DummyOperator
+
+def msys2_bash_invocation(command, msys2_bash='/c/scoop/apps/msys2/current/usr/bin/bash.exe'):
+    return '{0} -l -c "{1}"'.format(msys2_bash, command)
+
+args = {
+    'owner': 'restic',
+    'depends_on_past': False,
+    #'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': datetime(2020,7,11),
+    'retries': 0,
+}
+
+dag = DAG(
+    dag_id='restic_check__read_data',
+    schedule_interval=None,
+    dagrun_timeout=timedelta(minutes=300),
+    catchup=False,
+    default_args=args,
+)
+
+run_this_last = DummyOperator(
+    task_id='run_END',
+    dag=dag,
+)
+
+run_restic_check = BashOperator(
+    task_id='run_restic_check',
+    bash_command=msys2_bash_invocation("restic-do-check--read-data"),
+    dag=dag,
+)
+
+run_restic_check >> run_this_last
+
+if __name__ == "__main__":
+    dag.cli()

--- a/dags/restic_rebuild_index.py
+++ b/dags/restic_rebuild_index.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+
+from builtins import range
+from datetime import datetime, timedelta
+
+import airflow
+from airflow.models import DAG
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.dummy_operator import DummyOperator
+
+def msys2_bash_invocation(command, msys2_bash='/c/scoop/apps/msys2/current/usr/bin/bash.exe'):
+    return '{0} -l -c "{1}"'.format(msys2_bash, command)
+
+args = {
+    'owner': 'restic',
+    'depends_on_past': False,
+    #'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': datetime(2020,7,11),
+    'retries': 0,
+}
+
+dag = DAG(
+    dag_id='restic_rebuild_index',
+    schedule_interval=None,
+    dagrun_timeout=timedelta(minutes=300),
+    catchup=False,
+    default_args=args,
+)
+
+run_this_last = DummyOperator(
+    task_id='run_END',
+    dag=dag,
+)
+
+run_restic_check = BashOperator(
+    task_id='run_rebuild_index',
+    bash_command=msys2_bash_invocation("restic-execute-rebuild-index"),
+    dag=dag,
+)
+
+run_restic_check >> run_this_last
+
+if __name__ == "__main__":
+    dag.cli()


### PR DESCRIPTION
Add support for the maintenance scripts in https://github.com/jkniiv/simple_restic_backup_scripts
The scripts in question are:
  - `restic-do-check--read-data`: Checks the Restic repository for integrity,
    and with the --read-data flag it does a more extensive check;
  - `restic-execute-rebuild-index`: Rebuilds the Restic repository index based
    on actual stored data a.k.a. pack files;
  - `restic-run-backup--force`: Runs the Restic backup proper, this time with
    the --force flag which forces re-reading of the files to be backed.